### PR TITLE
fix: resolve picomatch ReDoS vulnerability (Dependabot #63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot-template",
-  "packageManager": "yarn@4.0.2",
+  "packageManager": "yarn@4.0.2+sha512.4e502bea682e7d8004561f916f1da2dfbe6f718024f6aa50bf8cd86f38ea3a94a7f1bf854a9ca666dd8eafcfb8d44baaa91bf5c7876e79a7aeac952c332f0e88",
   "main": "index.mjs",
   "type": "module",
   "nodemonConfig": {
@@ -29,6 +29,7 @@
   "resolutions": {
     "undici": "6.24.0",
     "minimatch": "9.0.7",
-    "tar": "7.5.11"
+    "tar": "7.5.11",
+    "picomatch": ">=4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,17 +2182,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1":
-  version: 2.3.2
-  resolution: "picomatch@npm:2.3.2"
-  checksum: b788ef8148a2415b9dec12f0bb350ae6a5830f8f1950e472abc2f5225494debf7d1b75eb031df0ceaea9e8ec3e7bad599e8dbf3c60d61b42be429ba41bff4426
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
+"picomatch@npm:>=4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pins `picomatch` to `>=4.0.4` via yarn resolutions to fix the ReDoS vulnerability via extglob quantifiers
- Resolves Dependabot alert #63

## Test plan

- [x] `yarn install` resolves picomatch to 4.0.4
- [x] Bot starts and runs normally